### PR TITLE
add importlib_metadata to dependencies for Python 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,10 @@ classifiers = [
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
 ]
 dependencies = [
-    "dargs",
+    "dargs>=0.2.6",
     "werkzeug",
     "waitress",
+    'importlib_metadata>=1.4; python_version < "3.8"',
 ]
 requires-python = ">=3.7"
 readme = "README.md"


### PR DESCRIPTION
Meet errors in https://github.com/deepmodeling/dpdispatcher/pull/372.